### PR TITLE
Tweaks to make module more friendly to DEVELOPERS

### DIFF
--- a/ballmer.js
+++ b/ballmer.js
@@ -42,10 +42,3 @@ exports.ballmer = function(options) {
 	}
 	return rs;
 }
-// console.log(randomizeCase("DEVELOPERS"))
-exports.ballmer({
-  flavor: "cancer",
-  total: 10,
-  newlines: true,
-  casing: "randomcase"
-}).pipe(process.stdout);


### PR DESCRIPTION
- Added a `.flavor` property to the `options` object.
- `"cancer"` is now an option in the flavor property of the options object in addition to `"developers"`, for a classic Ballmer quote.
- Changed `.case` to `.casing` (because `case` is a reserved js keyword and could become annoying).
- Changed the `developers` variable as it now just describes the final loremipsum `content`.
- Updated the default call to `ballmer`.
- Updated readme to cover the new option.
